### PR TITLE
Upgrade httpcomponents to 4.3.2 to allow for SNI support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,13 +224,13 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
-			<version>4.3.1</version>
+			<version>4.3.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpmime</artifactId>
-			<version>4.3.1</version>
+			<version>4.3.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.httpcomponents</groupId>
@@ -242,7 +242,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>fluent-hc</artifactId>
-			<version>4.3.1</version>
+			<version>4.3.2</version>
 		</dependency>
 
 		<!-- ***************************** STUFF FOR TESTING ******************************** -->


### PR DESCRIPTION
Hello,

A simple PR to upgrade httpcomponents from version 4.3.1 to version 4.3.2 as SNI support was added in 4.3.2 (see http://archive.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.3.x.txt).

Regards,

Benoit.
