### PR TITLE
 Upgrade httpcomponents to 4.3.2 to allow for SNI support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,13 +224,13 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
-			<version>4.3.1</version>
+			<version>4.3.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpmime</artifactId>
-			<version>4.3.1</version>
+			<version>4.3.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.httpcomponents</groupId>
@@ -242,7 +242,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>fluent-hc</artifactId>
-			<version>4.3.1</version>
+			<version>4.3.2</version>
 		</dependency>
 
 		<!-- ***************************** STUFF FOR TESTING ******************************** -->


### PR DESCRIPTION
Hello,

Same PR as previously but starting from the branch-0.4 stable branch.

Regards,

Benoit.
