### PR TITLE
increase httpclient version, closes #37

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,13 +224,13 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
-			<version>4.3.1</version>
+			<version>${apache.http.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpmime</artifactId>
-			<version>4.3.1</version>
+			<version>${apache.http.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.httpcomponents</groupId>
@@ -242,7 +242,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>fluent-hc</artifactId>
-			<version>4.3.1</version>
+			<version>${apache.http.version}</version>
 		</dependency>
 
 		<!-- to auto-detect mime type of uploaded resources -->
@@ -289,7 +289,9 @@
 
 	</dependencies>
 
-
+	<properties>
+		<apache.http.version>4.3.3</apache.http.version>
+	</properties>
 
 	<reporting>
 		<plugins>


### PR DESCRIPTION
As mentioned in #37 there is a problem with SNI configured servers which may return the wrong SSL certificate when connecting via `CkanClient`. There's a problem with version `4.3.1` of Apache's httpclient, which should be resolved in versions higher than `4.3.1` used by Jackan.

This PR just increases version of Apache http components to resolve that issue.
